### PR TITLE
chore: Update `logback-classic` dependency

### DIFF
--- a/01-Login/pom.xml
+++ b/01-Login/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.4.12</version>
+      <version>1.4.14</version>
     </dependency>
     <dependency>
       <groupId>com.auth0</groupId>


### PR DESCRIPTION
This PR updates the Maven lockfile reference for `logback-classic` to 1.4.14 to resolve a Snyk warning.